### PR TITLE
Fixing port referencing and docker dependencies

### DIFF
--- a/antora-playbook.content.yml
+++ b/antora-playbook.content.yml
@@ -1,6 +1,6 @@
 site:
   title: WTC Curriculum
-  url: http://localhost:8081
+  url: http://localhost:8051
   start_page: overview::index.adoc
   robots: disallow
 content:

--- a/antora.dockerfile
+++ b/antora.dockerfile
@@ -1,3 +1,4 @@
-FROM antora/antora:2.3.4
+FROM antora/antora:latest
+RUN npm install -g npm@latest
 RUN yarn global add http-server onchange
 WORKDIR /site

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     environment:
       - GIT_CREDENTIALS
     ports:
-      - 8081:8080
+      - 8051:8080
     volumes:
       - .:/site


### PR DESCRIPTION
The `antora.dockerfile` runs npm packages that require the latest version of npm, so fixing that by making sure npm stays on the latest stable build, as well as keeping antora on the latest stable build (I don't think that is required though, so can be removed). Also refrences of ports were conflicting with the actual ports opening in the `docker-compose.yml` file, so changing the ports to the `8051` as refrenced through all the project